### PR TITLE
tbr profit calc update

### DIFF
--- a/src/telliot_feeds/reporters/rewards/time_based_rewards.py
+++ b/src/telliot_feeds/reporters/rewards/time_based_rewards.py
@@ -26,9 +26,9 @@ async def get_time_based_rewards(oracle: Tellor360OracleContract) -> int:
         error = last_val_status.error
         logger.warning(f"Unable to calculate time-based rewards for reporter: {error}")
         return 0
-
+    current_year = await oracle.read("timeBasedReward")
     reward = (
-        (TimeStamp.now().ts - time_of_last_new_value) * 4.753213172e18
-    ) / 1  # 0.5 tokens (5e17) dispersed every five min (300 sec)
+        (TimeStamp.now().ts - time_of_last_new_value) * (await oracle.read("timeBasedReward"))[0]
+    ) / 300  # amount of tokens (5e17) dispersed every five min (300 sec)
 
     return reward #if reward < tbr else tbr

--- a/src/telliot_feeds/utils/abi.py
+++ b/src/telliot_feeds/utils/abi.py
@@ -298,6 +298,13 @@ gorli_playground_abi = [
         "type": "function",
     },
     {
+        "inputs": [],
+        "name": "timeBasedReward",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
         "inputs": [
             {"internalType": "bytes32", "name": "", "type": "bytes32"},
             {"internalType": "uint256", "name": "", "type": "uint256"},


### PR DESCRIPTION
Updated TBR profit calculation to use timeBasedRewards func straight from the contract, which already calculates what is the current year and what's the current TBR amount being dispersed. So now we should have profit calculations for TBRs for 100y.