### PR TITLE
updated pulseXSource, plsNfetch feeds for mainnet

### DIFF
--- a/src/telliot_feeds/feeds/fetch_usd_feed.py
+++ b/src/telliot_feeds/feeds/fetch_usd_feed.py
@@ -3,6 +3,7 @@ from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.pulsex_subgraph import PulseXSubgraphSource
+from telliot_feeds.sources.price.spot.pulsex_subgraph import mainnet_tokens
 from telliot_feeds.sources.price.spot.fetch_usd_mock import FetchUsdMockSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
 #from telliot_feeds.sources.price.spot.pulsex_fetch_dai import PulseXFETCHDAISource
@@ -17,13 +18,26 @@ if os.getenv("FETCH_USD_MOCK_PRICE"):
         source=FetchUsdMockSpotPriceSource(asset="fetch", currency="usd")
         )
         
-else:
-    fetch_usd_median_feed = DataFeed(
-        query=SpotPrice(asset="fetch", currency="usd"),
-        source=PriceAggregator(
-            asset="fetch",
-            currency="usd",
-            algorithm="median",
-            sources=[PulseXSubgraphSource(asset="fetch", currency="usd")],
+else: # TODO: update the logic and sources when FETCH is available in other places
+    if os.getenv("NETWORK_ID") == "369" and "fetch" in mainnet_tokens:
+        fetch_usd_median_feed = DataFeed(
+            query=SpotPrice(asset="fetch", currency="usd"),
+            source=PriceAggregator(
+                asset="fetch",
+                currency="usd",
+                algorithm="median",
+                sources=[PulseXSubgraphSource(asset="fetch", currency="usd")],
+            )
         )
-    )
+    elif os.getenv("NETWORK_ID") == "943":
+        fetch_usd_median_feed = DataFeed(
+            query=SpotPrice(asset="fetch", currency="usd"),
+            source=PriceAggregator(
+                asset="fetch",
+                currency="usd",
+                algorithm="median",
+                sources=[PulseXSubgraphSource(asset="fetch", currency="usd")],
+            )
+        )
+    else:
+       raise ValueError("There's no FETCH address yet for mainnet")

--- a/src/telliot_feeds/feeds/pls_usd_feed.py
+++ b/src/telliot_feeds/feeds/pls_usd_feed.py
@@ -6,18 +6,34 @@ from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSou
 from telliot_feeds.sources.price.spot.uniswapV3 import UniswapV3PriceSource
 from telliot_feeds.sources.price.spot.pulsex_subgraph import PulseXSubgraphSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
+import os
+from dotenv import load_dotenv
+load_dotenv()
 
-pls_usd_median_feed = DataFeed(
-    query=SpotPrice(asset="PLS", currency="USD"),
-    source=PriceAggregator(
-        asset="pls",
-        currency="usd",
-        algorithm="median",
-        sources=[
-            #CoinGeckoSpotPriceSource(asset="pls", currency="usd"),
-            #CoinpaprikaSpotPriceSource(asset="pls-pulsechain", currency="usd"),
-            #UniswapV3PriceSource(asset="pls", currency="usd"),
-            PulseXSubgraphSource(asset="wpls", currency="usd"), #testnet wpls. Check pulsex_subgraph.py to confirm token address
-        ],
-    ),
-)
+if os.getenv("NETWORK_ID") == "943":
+    pls_usd_median_feed = DataFeed(
+        query=SpotPrice(asset="PLS", currency="USD"),
+        source=PriceAggregator(
+            asset="pls",
+            currency="usd",
+            algorithm="median",
+            sources=[
+                PulseXSubgraphSource(asset="wpls", currency="usd"), 
+            ],
+        ),
+    )
+else:
+    pls_usd_median_feed = DataFeed(
+        query=SpotPrice(asset="PLS", currency="USD"),
+        source=PriceAggregator(
+            asset="pls",
+            currency="usd",
+            algorithm="median",
+            sources=[
+                CoinGeckoSpotPriceSource(asset="pls", currency="usd"),
+                CoinpaprikaSpotPriceSource(asset="pls-pulsechain", currency="usd"),
+                UniswapV3PriceSource(asset="pls", currency="usd"),
+                PulseXSubgraphSource(asset="wpls", currency="usd"), 
+            ],
+        ),
+    )

--- a/src/telliot_feeds/sources/price/spot/pulsex_subgraph.py
+++ b/src/telliot_feeds/sources/price/spot/pulsex_subgraph.py
@@ -1,4 +1,5 @@
 import os
+from dotenv import load_dotenv
 
 from dataclasses import dataclass
 from dataclasses import field
@@ -13,16 +14,45 @@ from telliot_feeds.pricing.price_source import PriceSource
 from telliot_feeds.utils.log import get_logger
 
 logger = get_logger(__name__)
-pulsex_subgraph_supporten_tokens = {
+
+load_dotenv()
+network_id = os.getenv("NETWORK_ID")
+
+testnet_graph = {
+    "pulsex": "https://graph.v4.testnet.pulsechain.com",
+}
+testnet_tokens = {
     "dai": "0x826e4e896cc2f5b371cd7bb0bd929db3e3db67c0",
     "usdc": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-    "plsx": "0x8a810ea8b121d08342e9e7696f4a9915cbe494b7", #testnet
-    "fetch": "0xC0573e2Fc47B26fb05097a553BBfcf0166bada0A", #testnet FETCH address
-    "wpls": "0x70499adebb11efd915e3b69e700c331778628707", #testnet
-    "hex": "0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39", #testnet
-    "inc": "0x6eFAfcb715F385c71d8AF763E8478FeEA6faDF63", #testnet
-    "loan": "0x2720F69787cE6ba408fB6e2282d7640E805DF367", #testnet
+    "plsx": "0x8a810ea8b121d08342e9e7696f4a9915cbe494b7",
+    "fetch": "0xC0573e2Fc47B26fb05097a553BBfcf0166bada0A",
+    "wpls": "0x70499adebb11efd915e3b69e700c331778628707",
+    "hex": "0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39",
+    "inc": "0x6eFAfcb715F385c71d8AF763E8478FeEA6faDF63",
+    "loan": "0x2720F69787cE6ba408fB6e2282d7640E805DF367",
 }
+
+mainnet_graph = {
+    "pulsex": "https://graph.pulsechain.com",
+}
+mainnet_tokens = {
+    "wpls": "0xa1077a294dde1b09bb078844df40758a5d0f9a27",
+    "dai": "0xefd766ccb38eaf1dfd701853bfce31359239f305",
+    "usdc": "0x15d38573d2feeb82e7ad5187ab8c1d52810b1f07",
+    "plsx": "0x95b303987a60c71504d99aa1b13b4da07b0790ab",
+    #"fetc": "0xC0573e2Fc47B26fb05097a553BBfcf0166bada0A", #update when we have the address
+    "hex": "0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39",
+    "inc": "0x2fa878ab3f87cc1c9737fc071108f904c0b0c95d",
+    "loan": "0x9159f1d2a9f51998fc9ab03fbd8f265ab14a1b3b",
+}
+
+if network_id == "369":  # mainnet
+    pulsex_subgraph_supporten_tokens, url = mainnet_tokens, mainnet_graph
+elif network_id == "943":  # testnet
+    pulsex_subgraph_supporten_tokens, url = testnet_tokens, testnet_graph
+else:
+    raise ValueError("Unsupported pulsexSubgraph NETWORK_ID")
+
 
 
 class PulseXSubgraphService(WebPriceService):
@@ -30,7 +60,7 @@ class PulseXSubgraphService(WebPriceService):
 
     def __init__(self, **kwargs: Any) -> None:
         kwargs["name"] = "PulseX Subgraph Price Service"
-        kwargs["url"] = "https://graph.v4.testnet.pulsechain.com"
+        kwargs["url"] = url["pulsex"]
         kwargs["timeout"] = 10.0
         super().__init__(**kwargs)
 


### PR DESCRIPTION
PulseX source to report controlled by NETWORK_ID. If set to 369 will report mainnet prices. If set to 943 will report to testnet.

Error handling if there's no FETCH address yet in mainnet to report.

pulseXSource updated with modular graph urls to use and dependent only on network_id instead of adding multiple variables in .env.