### PR TITLE
network_id and 'fetch in pulsechain' explainer update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@
 #0.001 is the default launch price in testnet.
 FETCH_USD_MOCK_PRICE=0.001
 
-#DVM is going to use this chain_id. Use 943 for testnet or 369 for mainnet.
+#DVM is going to use this for monitoring and Telliot to get prices for pulseX source. 
+#Use 943 for testnet or 369 for mainnet.
 NETWORK_ID=369
 
 #Discord variables to sent alerts to

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,13 +71,13 @@ Options:
                                   Address of custom autopay contract
   -360, --tellor-360 / -flex, --tellor-flex
                                   Choose between Tellor 360 or Flex contracts
-  -s, --stake FLOAT               ❗Telliot will automatically stake more TRB(PLS in Pulsechain)
+  -s, --stake FLOAT               ❗Telliot will automatically stake more TRB(FETCH in Pulsechain)
                                   if your stake is below or falls below the
                                   stake amount required to report. If you
                                   would like to stake more than required,
                                   enter the TOTAL stake amount you wish to be
                                   staked. For example, if you wish to stake
-                                  1000 TRB, enter 1000.
+                                  1000 FETCH, enter 1000.
   -mnb, --min-native-token-balance FLOAT
                                   Minimum native token balance required to
                                   report. Denominated in ether.
@@ -219,7 +219,7 @@ The reporter will automatically attempt to stake the required amount, but if you
 telliot report -a acct1 -s 2000 -ncr -rf
 ```
 
-If the reporter account's actual stake is reduced after a dispute, the reporter will attempt to stake the difference in TRB(PLS in Pulsechain) to return to the original desired stake amount.
+If the reporter account's actual stake is reduced after a dispute, the reporter will attempt to stake the difference in TRB(FETCH in Pulsechain) to return to the original desired stake amount.
 
 ### Withdraw Stake
 

--- a/src/telliot_feeds/cli/constants.py
+++ b/src/telliot_feeds/cli/constants.py
@@ -1,5 +1,5 @@
 STAKE_MESSAGE = (
-    "\U00002757Telliot will automatically stake more TRB(PLS in Pulsechain) "
+    "\U00002757Telliot will automatically stake more TRB(FETCH in Pulsechain) "
     "if your stake is below or falls below the stake amount required to report.\n"
     "If you would like to stake more than required, enter the TOTAL stake amount you wish to be staked.\n"
     "For example, if you wish to stake 1000 TRB, enter 1000.\n"

--- a/src/telliot_feeds/reporters/stake.py
+++ b/src/telliot_feeds/reporters/stake.py
@@ -35,11 +35,11 @@ class Stake(GasFees):
             msg = f"Unable to read account balance: {status.error}"
             return None, error_status(msg, status.e, log=logger.error)
 
-        logger.info(f"Current wallet TRB(PLS in Pulsechain) balance: {self.to_ether(wallet_balance)!r}")
+        logger.info(f"Current wallet TRB(FETCH in Pulsechain) balance: {self.to_ether(wallet_balance)!r}")
         return wallet_balance, status
 
     async def check_allowance(self, amount: int) -> Tuple[Optional[int], ResponseStatus]:
-        """ "Read the spender allowance for the accounts TRB(PLS in Pulsechain)"""
+        """ "Read the spender allowance for the accounts TRB(FETCH in Pulsechain)"""
         allowance, allowance_status = await self.token.read(
             "allowance", owner=self.acct_address, spender=self.oracle.address
         )
@@ -51,7 +51,7 @@ class Stake(GasFees):
         return allowance, allowance_status
 
     async def approve_spending(self, amount: int) -> Tuple[bool, ResponseStatus]:
-        """Approve contract to spend TRB(PLS in Pulsechain) tokens"""
+        """Approve contract to spend TRB(FETCH in Pulsechain) tokens"""
         logger.info(f"Approving {self.oracle.address} token spending: {amount}...")
         # calculate and set gas params
         status = self.update_gas_fees()
@@ -75,7 +75,7 @@ class Stake(GasFees):
 
     async def deposit_stake(self, amount: int) -> Tuple[bool, ResponseStatus]:
         """Deposits stake into the oracle contract"""
-        # check TRB(PLS in Pulsechain) wallet balance!
+        # check TRB(FETCH in Pulsechain) wallet balance!
         wallet_balance, wallet_balance_status = await self.get_current_token_balance()
         if wallet_balance is None or not wallet_balance_status.ok:
             return False, wallet_balance_status
@@ -84,7 +84,7 @@ class Stake(GasFees):
             msg = (
                 f"Amount to stake: {self.to_ether(amount):.04f} "
                 f"is greater than your balance: {self.to_ether(wallet_balance):.04f} so "
-                "not enough TRB(PLS in Pulsechain) to cover the stake"
+                "not enough TRB(FETCH in Pulsechain) to cover the stake"
             )
             return False, error_status(msg, log=logger.warning)
 


### PR DESCRIPTION
Added info to NETWORK_ID var and fixed 'pls in pulsechain' for TRB, which should be FETCH, not PLS.